### PR TITLE
Remove unnecessary call to generate export

### DIFF
--- a/scripts/data-upload.sh
+++ b/scripts/data-upload.sh
@@ -4,8 +4,6 @@ host=$1
 user=$2
 db=$3
 
-# Generates the last version of the csv
-pipenv run export
 cd app/data
 # removes the first line (column names)
 sed -i 1d time_series_export.csv


### PR DESCRIPTION
Currently, we are updating the `export_time_series.csv` file, so we must not re-generate that file.