### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,13 @@ FROM tiangolo/uvicorn-gunicorn-fastapi:python3.7
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 
-# PREPARE FOLDER
-WORKDIR /api
-
 # COPY DEPENDENCIES
 COPY requirements.txt ./
+
+# COPY PROJECT
+COPY ./app /app/app
 
 # INSTALL DEPENDENCIES
 RUN pip install -r requirements.txt
 
-# COPY PROJECT
-COPY . /
+EXPOSE 80


### PR DESCRIPTION
Fixing an error when starting the container created from the Dockerfile.
The error was related to nonexistent import because of relative paths.